### PR TITLE
Remove resolver from stack.yaml.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,3 @@
-resolver: lts-3.14
 packages:
 extra-deps:
 - container-1.0


### PR DESCRIPTION
Hardcoded resolver breaks GHCJS build